### PR TITLE
Sync test message and behaviour in feature.t

### DIFF
--- a/t/feature.t
+++ b/t/feature.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More;
 
-plan skip_all => 'feature check irrelevant on v5.8'
+plan skip_all => 'feature check irrelevant on Perl v5.10 and below'
     if $] <= 5.010;
 
 {


### PR DESCRIPTION
Did say "v5.8" but check for less than or equal to 5.10. Now the message
matches the behaviour.

----------------

This is my rather rushed attempt at a pull request for my August CPAN Pull Request Challenge :-) Sorry I wasn't able to do something more substantial.

Part of the reason I didn't do anything better was because I had a lot of trouble getting your Dist::Zilla plugins to play nicely and eventually had to give up... currently I'm getting a warning and an error:

**Pod::Elemental warning**

    not handling plain * items yet at /home/alex/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Pod/Elemental/Transformer/List/Converter.pm line 57.

**@Filter/Manifest error**

    Could not decode MANIFEST; bytes from coderef added by @Filter/Manifest (Dist::Zilla::Plugin::Manifest line 55); error was: Can't decode text from 'bytes' encoding; maybe you need the [Encoding] plugin to specify an encoding at /home/alex/perl5/perlbrew/perls/perl-5.16.3/lib/site_perl/5.16.3/Dist/Zilla/Role/File.pm line 153.